### PR TITLE
fix: correct OpusCompile workflow for shim linking on Windows and Linux x86

### DIFF
--- a/.github/workflows/OpusCompile.yml
+++ b/.github/workflows/OpusCompile.yml
@@ -141,8 +141,10 @@ jobs:
       - name: Build with shim
         working-directory: ./build
         run: |
-          if [[ "${{ matrix.arch }}" == "x64" || "${{ matrix.arch }}" == "x86" ]]; then
-            CC=gcc
+          if [[ "${{ matrix.arch }}" == "x64" ]]; then
+            CC="gcc -m64"
+          elif [[ "${{ matrix.arch }}" == "x86" ]]; then
+            CC="gcc -m32"
           elif [[ "${{ matrix.arch }}" == "arm64" ]]; then
             CC=${{ env.C_COMPILER }}
           elif [[ "${{ matrix.arch }}" == "arm32" ]]; then
@@ -209,9 +211,10 @@ jobs:
         working-directory: ./build
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ env.ARCH }}
+          if "${{ env.ARCH }}"=="Win32" (set "VCARCH=x86") else if "${{ env.ARCH }}"=="x64" (set "VCARCH=amd64") else if "${{ env.ARCH }}"=="ARM64" (set "VCARCH=amd64_arm64") else if "${{ env.ARCH }}"=="ARM" (set "VCARCH=amd64_arm")
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCARCH%
           cl /O2 /I..\opus\include /c ..\OpusSharp.Natives\opus_shim.c /Foopus_shim.obj
-          link /DLL /OUT:opus.dll /DEF:NUL opus_shim.obj Release\opus.lib
+          link /DLL /OUT:opus.dll opus_shim.obj Release\opus.lib
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/OpusCompile.yml
+++ b/.github/workflows/OpusCompile.yml
@@ -213,8 +213,8 @@ jobs:
         run: |
           if "${{ env.ARCH }}"=="Win32" (set "VCARCH=x86") else if "${{ env.ARCH }}"=="x64" (set "VCARCH=amd64") else if "${{ env.ARCH }}"=="ARM64" (set "VCARCH=amd64_arm64") else if "${{ env.ARCH }}"=="ARM" (set "VCARCH=amd64_arm")
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCARCH%
-          cl /O2 /I..\opus\include /c ..\OpusSharp.Natives\opus_shim.c /Foopus_shim.obj
-          link /DLL /OUT:opus.dll opus_shim.obj Release\opus.lib
+          cl /O2 /MD /I..\opus\include /c ..\OpusSharp.Natives\opus_shim.c /Foopus_shim.obj
+          link /DLL /OUT:opus.dll opus_shim.obj Release\opus.lib ucrt.lib vcruntime.lib msvcrt.lib
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

Follow-up to #48 — fixes the `Build with shim` CI step that was failing on Windows (x86 and arm64) and Linux x86 after the non-variadic CTL shim was introduced.

## Changes

**`.github/workflows/OpusCompile.yml`**

### Windows: vcvarsall arch mapping
The `ARCH` env var is set for CMake (`Win32`, `x64`, `ARM64`) but `vcvarsall.bat` expects different names (`x86`, `amd64`, `amd64_arm64`). Added a mapping step so the correct MSVC toolchain is initialized for each target.

### Windows x86: CRT linker error
When manually invoking `link.exe` to combine the static `opus.lib` with the shim into a DLL, the x86 SEH symbol `__except_handler4_common` was unresolved. This symbol lives in `vcruntime.lib` and isn't automatically pulled in during manual linking. Fixed by explicitly specifying `ucrt.lib`, `vcruntime.lib`, and `msvcrt.lib` on the link command.

### Linux x86: architecture mismatch
The shim was being compiled as 64-bit (default `gcc`) while `libopus.a` was built as 32-bit (`-m32`). Fixed by passing `-m32`/`-m64` to gcc in the shim build step to match the opus static library architecture.

## CI verification

All jobs pass on the fork: https://github.com/katruud/OpusSharp/actions/runs/24160669210

| Platform | Status |
|----------|--------|
| Android (x64, x86, arm64, arm32) | Passed |
| Linux (x64, x86, arm64, arm32) | Passed |
| Windows (x64, x86, arm64) | Passed |
| macOS (x64, arm64) | Passed |
| iOS (device, simulator-arm64, simulator-x86_64) | Passed |
| iOS-universal | Passed |
| Wasm | Passed |
| Create-Runtimes | Passed |

## Local testing

The shim-enabled `opus.dylib` was built locally and tested in the [Basis](https://github.com/BasisVR/Basis) Unity project on macOS ARM64 (Apple Silicon). `OpusEncoder.Ctl(OPUS_SET_BITRATE)` and `OpusEncoder.Ctl(OPUS_SET_COMPLEXITY)` calls that previously failed with `OPUS_BAD_ARG` now succeed, and voice audio networking initializes without errors.