### PR TITLE
fix: export opus and shim symbols from Windows DLL 

### DIFF
--- a/.github/workflows/OpusCompile.yml
+++ b/.github/workflows/OpusCompile.yml
@@ -214,7 +214,7 @@ jobs:
           if "${{ env.ARCH }}"=="Win32" (set "VCARCH=x86") else if "${{ env.ARCH }}"=="x64" (set "VCARCH=amd64") else if "${{ env.ARCH }}"=="ARM64" (set "VCARCH=amd64_arm64") else if "${{ env.ARCH }}"=="ARM" (set "VCARCH=amd64_arm")
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCARCH%
           cl /O2 /MD /I..\opus\include /c ..\OpusSharp.Natives\opus_shim.c /Foopus_shim.obj
-          link /DLL /OUT:opus.dll opus_shim.obj Release\opus.lib ucrt.lib vcruntime.lib msvcrt.lib
+          link /DLL /OUT:opus.dll opus_shim.obj /WHOLEARCHIVE:Release\opus.lib ucrt.lib vcruntime.lib msvcrt.lib
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/OpusCompile.yml
+++ b/.github/workflows/OpusCompile.yml
@@ -214,7 +214,9 @@ jobs:
           if "${{ env.ARCH }}"=="Win32" (set "VCARCH=x86") else if "${{ env.ARCH }}"=="x64" (set "VCARCH=amd64") else if "${{ env.ARCH }}"=="ARM64" (set "VCARCH=amd64_arm64") else if "${{ env.ARCH }}"=="ARM" (set "VCARCH=amd64_arm")
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" %VCARCH%
           cl /O2 /MD /I..\opus\include /c ..\OpusSharp.Natives\opus_shim.c /Foopus_shim.obj
-          link /DLL /OUT:opus.dll opus_shim.obj /WHOLEARCHIVE:Release\opus.lib ucrt.lib vcruntime.lib msvcrt.lib
+          dumpbin /symbols Release\opus.lib > opus_symbols.txt
+          powershell -NoProfile -Command "$s = (gc opus_symbols.txt) | Where-Object {$_ -match 'External\s+\|\s+(opus_\S+)'} | ForEach-Object { [regex]::Match($_, 'External\s+\|\s+(\S+)').Groups[1].Value -replace '^_','' } | Sort-Object -Unique; [IO.File]::WriteAllText('opus.def', \"EXPORTS`r`n\" + ($s -join \"`r`n\") + \"`r`n\")"
+          link /DLL /OUT:opus.dll /DEF:opus.def opus_shim.obj Release\opus.lib ucrt.lib vcruntime.lib msvcrt.lib
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/OpusSharp.Natives/opus_shim.c
+++ b/OpusSharp.Natives/opus_shim.c
@@ -18,112 +18,118 @@
 #include <opus.h>
 #include <opus_multistream.h>
 
+#ifdef _WIN32
+#  define SHIM_EXPORT __declspec(dllexport)
+#else
+#  define SHIM_EXPORT
+#endif
+
 /* === Encoder CTL === */
 
-int opussharp_encoder_ctl(OpusEncoder *st, int request)
+SHIM_EXPORT SHIM_EXPORT int opussharp_encoder_ctl(OpusEncoder *st, int request)
 {
     return opus_encoder_ctl(st, request);
 }
 
-int opussharp_encoder_ctl_i(OpusEncoder *st, int request, int value)
+SHIM_EXPORT int opussharp_encoder_ctl_i(OpusEncoder *st, int request, int value)
 {
     return opus_encoder_ctl(st, request, value);
 }
 
-int opussharp_encoder_ctl_p(OpusEncoder *st, int request, void *value)
+SHIM_EXPORT int opussharp_encoder_ctl_p(OpusEncoder *st, int request, void *value)
 {
     return opus_encoder_ctl(st, request, value);
 }
 
-int opussharp_encoder_ctl_pi(OpusEncoder *st, int request, void *data, int data2)
+SHIM_EXPORT int opussharp_encoder_ctl_pi(OpusEncoder *st, int request, void *data, int data2)
 {
     return opus_encoder_ctl(st, request, data, data2);
 }
 
-int opussharp_encoder_ctl_ip(OpusEncoder *st, int request, int data, void *data2)
+SHIM_EXPORT int opussharp_encoder_ctl_ip(OpusEncoder *st, int request, int data, void *data2)
 {
     return opus_encoder_ctl(st, request, data, data2);
 }
 
-int opussharp_encoder_ctl_pp(OpusEncoder *st, int request, void *data, void *data2)
+SHIM_EXPORT int opussharp_encoder_ctl_pp(OpusEncoder *st, int request, void *data, void *data2)
 {
     return opus_encoder_ctl(st, request, data, data2);
 }
 
 /* === Decoder CTL === */
 
-int opussharp_decoder_ctl(OpusDecoder *st, int request)
+SHIM_EXPORT int opussharp_decoder_ctl(OpusDecoder *st, int request)
 {
     return opus_decoder_ctl(st, request);
 }
 
-int opussharp_decoder_ctl_i(OpusDecoder *st, int request, int value)
+SHIM_EXPORT int opussharp_decoder_ctl_i(OpusDecoder *st, int request, int value)
 {
     return opus_decoder_ctl(st, request, value);
 }
 
-int opussharp_decoder_ctl_p(OpusDecoder *st, int request, void *value)
+SHIM_EXPORT int opussharp_decoder_ctl_p(OpusDecoder *st, int request, void *value)
 {
     return opus_decoder_ctl(st, request, value);
 }
 
 /* === DRED Decoder CTL === */
 
-int opussharp_dred_decoder_ctl(OpusDREDDecoder *dred_dec, int request)
+SHIM_EXPORT int opussharp_dred_decoder_ctl(OpusDREDDecoder *dred_dec, int request)
 {
     return opus_dred_decoder_ctl(dred_dec, request);
 }
 
-int opussharp_dred_decoder_ctl_p(OpusDREDDecoder *dred_dec, int request, void *value)
+SHIM_EXPORT int opussharp_dred_decoder_ctl_p(OpusDREDDecoder *dred_dec, int request, void *value)
 {
     return opus_dred_decoder_ctl(dred_dec, request, value);
 }
 
 /* === Multistream Encoder CTL === */
 
-int opussharp_ms_encoder_ctl(OpusMSEncoder *st, int request)
+SHIM_EXPORT int opussharp_ms_encoder_ctl(OpusMSEncoder *st, int request)
 {
     return opus_multistream_encoder_ctl(st, request);
 }
 
-int opussharp_ms_encoder_ctl_i(OpusMSEncoder *st, int request, int value)
+SHIM_EXPORT int opussharp_ms_encoder_ctl_i(OpusMSEncoder *st, int request, int value)
 {
     return opus_multistream_encoder_ctl(st, request, value);
 }
 
-int opussharp_ms_encoder_ctl_p(OpusMSEncoder *st, int request, void *value)
+SHIM_EXPORT int opussharp_ms_encoder_ctl_p(OpusMSEncoder *st, int request, void *value)
 {
     return opus_multistream_encoder_ctl(st, request, value);
 }
 
-int opussharp_ms_encoder_ctl_pi(OpusMSEncoder *st, int request, void *data, int data2)
+SHIM_EXPORT int opussharp_ms_encoder_ctl_pi(OpusMSEncoder *st, int request, void *data, int data2)
 {
     return opus_multistream_encoder_ctl(st, request, data, data2);
 }
 
-int opussharp_ms_encoder_ctl_ip(OpusMSEncoder *st, int request, int data, void *data2)
+SHIM_EXPORT int opussharp_ms_encoder_ctl_ip(OpusMSEncoder *st, int request, int data, void *data2)
 {
     return opus_multistream_encoder_ctl(st, request, data, data2);
 }
 
-int opussharp_ms_encoder_ctl_pp(OpusMSEncoder *st, int request, void *data, void *data2)
+SHIM_EXPORT int opussharp_ms_encoder_ctl_pp(OpusMSEncoder *st, int request, void *data, void *data2)
 {
     return opus_multistream_encoder_ctl(st, request, data, data2);
 }
 
 /* === Multistream Decoder CTL === */
 
-int opussharp_ms_decoder_ctl(OpusMSDecoder *st, int request)
+SHIM_EXPORT int opussharp_ms_decoder_ctl(OpusMSDecoder *st, int request)
 {
     return opus_multistream_decoder_ctl(st, request);
 }
 
-int opussharp_ms_decoder_ctl_i(OpusMSDecoder *st, int request, int value)
+SHIM_EXPORT int opussharp_ms_decoder_ctl_i(OpusMSDecoder *st, int request, int value)
 {
     return opus_multistream_decoder_ctl(st, request, value);
 }
 
-int opussharp_ms_decoder_ctl_p(OpusMSDecoder *st, int request, void *value)
+SHIM_EXPORT int opussharp_ms_decoder_ctl_p(OpusMSDecoder *st, int request, void *value)
 {
     return opus_multistream_decoder_ctl(st, request, value);
 }


### PR DESCRIPTION
## Problem                                                                         
                                                                                     
  On Windows, MSVC link does not automatically export symbols from static            
  libraries into a DLL (unlike Linux `--whole-archive` or macOS `-force_load`).
  This resulted in `opus.dll` having zero exports, causing P/Invoke failures
  at runtime.

  ## Changes

  - **`opus_shim.c`**: Added `SHIM_EXPORT` macro (`__declspec(dllexport)` on
    Windows, no-op elsewhere) to all `opussharp_*` shim functions so they are
    explicitly exported from the DLL.

  - **`OpusCompile.yml`** (Windows build step): Generate a `.def` file from
    `dumpbin /symbols` output listing all `opus_*` symbols from the static lib,
    then pass `/DEF:opus.def` to the linker so those symbols are also exported.
    This replaces the non-functional `/WHOLEARCHIVE` approach.

  ## Verification

  Built and tested via CI:
  https://github.com/towneh/OpusSharp/actions/runs/24208499689
  Resulting `All-Runtimes.zip` was successfully imported into the Basis Unity
  project and confirmed working on Windows and macOS. Successfully build Android APK with runtime.