### PR TITLE
fix: link libm in Android shim build to resolve missing math symbols 

### DIFF
--- a/.github/workflows/OpusCompile.yml
+++ b/.github/workflows/OpusCompile.yml
@@ -71,7 +71,9 @@ jobs:
             -I../opus/include \
             ../OpusSharp.Natives/opus_shim.c \
             -Wl,--whole-archive libopus.a -Wl,--no-whole-archive \
-            -Wl,-z,max-page-size=16384,-z,common-page-size=16384
+            -Wl,-z,max-page-size=16384,-z,common-page-size=16384 \
+            -Wl,--no-undefined \
+            -lm
 
       - name: Check Alignment
         if: ${{ env.CHECK_ALIGNMENT == 'true' }}


### PR DESCRIPTION
## Summary                                                                                                                                                                

  The Android `libopus.so` is currently produced without `-lm`, so math functions used by CELT/SILK (`sqrt`, `log`, `exp`, etc.) end up as unresolved symbols. On Android,  
  `libm` is a separate shared object, and bionic reports the resulting load failure as a generic `library "opus" not found` error.                                          
                                                                                                                                                                            
  In Unity IL2CPP this manifests as a `DllNotFoundException` the moment `OpusEncoder` / `OpusDecoder` is constructed on arm64 devices — reproduced on a Pixel 8 Pro, but it 
  affects all Android arches produced by this workflow. The file is present in the APK and in the device's `nativeLibraryDir`, the ELF is arm64 and 16 KB-page aligned,     
  SONAME is clean — but `readelf -d` shows only `DT_NEEDED: libdl.so, libc.so` with no `libm.so`, which is the smoking gun.                                                 
                                                                                                                                                                            
  The Linux shim step already passes `-lm`; the Android step was simply missing it.                                                                                         
                                                                                                                                                                            
  ## Changes                                                                                                                                                                
                                                                                                                                                                            
  - Add `-lm` to the Android "Build with shim" link step, matching the Linux step.                                                                                          
  - Add `-Wl,--no-undefined` so any future missing dependency fails the GitHub Actions build loudly instead of silently producing a broken `.so` that only fails at `dlopen`
   time on-device.                                        